### PR TITLE
The ticks will cause it to break

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
           # Provide personal access token
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Using zola fork for html changes
-          ZOLA_REPO: '''https://github.com/rwtechwiki/obsidian-zola.git'''
+          ZOLA_REPO: https://github.com/rwtechwiki/obsidian-zola.git


### PR DESCRIPTION
In YAML you do not need to escape strings that stay on a single line like this, so just having the value should work. 